### PR TITLE
fix: add GNOME Shell 47-49 to supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GNOME Shell extension that tracks your AI usage limits for **Claude** (Anthropic) and **Codex/ChatGPT** (OpenAI) and displays remaining percentages in the top panel.
 
-![GNOME Shell 45+](https://img.shields.io/badge/GNOME_Shell-45%20%7C%2046-blue)
+![GNOME Shell 45+](https://img.shields.io/badge/GNOME_Shell-45--49-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-green)
 
 ## Features
@@ -16,7 +16,7 @@ GNOME Shell extension that tracks your AI usage limits for **Claude** (Anthropic
 
 ## Prerequisites
 
-- GNOME Shell 45 or 46
+- GNOME Shell 45 to 49
 - Active [Claude](https://claude.ai) and/or [Codex](https://chatgpt.com) accounts with OAuth credentials on disk:
   - Claude: `~/.claude/.credentials.json`
   - Codex: `~/.codex/auth.json`

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -5,7 +5,10 @@
   "version": 1,
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47",
+    "48",
+    "49"
   ],
   "settings-schema": "org.gnome.shell.extensions.brainusage"
 }


### PR DESCRIPTION
## Summary

- Add GNOME Shell versions 47, 48, and 49 to `shell-version` in `extension/metadata.json`
- Update README badge and prerequisites to reflect supported range (45-49)

## Problem

On GNOME Shell 47+, the extension is silently ignored after installation. Running `gnome-extensions enable brainusage@altairinglorious` returns `"Extension does not exist"` even though the files are correctly installed in `~/.local/share/gnome-shell/extensions/`.

Root cause: `metadata.json` only declared `["45", "46"]` in `shell-version`, and GNOME Shell skips extensions that don't include the running version.

Closes #1

## Test plan

- [x] Tested on GNOME Shell 49.5 (Wayland, CachyOS) — extension loads and activates correctly
- [ ] Verify no regressions on GNOME Shell 45/46